### PR TITLE
README: fix MX_HOMESERVER protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Configuration is done with environment variables.
 |-----------------|---------------------------|------------------------------|
 | HTTP_ADDRESS    | Adress to listen on       | `localhost`                  |
 | HTTP_PORT       | Port to listen on         | `8080`                       |
-| MX_HOMESERVER   | Matrix homeserver         | `matrix.org`                 |
+| MX_HOMESERVER   | Matrix homeserver         | `https://matrix.org`         |
 | MX_ID           | Matrix user ID            | `@mr_panic:matrix.org`       |
 | MX_ROOMID       | Matrix room to join       | `!ilXTTTTTTuDmsz:matrix.org` |
 | MX_TOKEN        | Matrix access token       | `rstienrsrseintrisetnrte`    |


### PR DESCRIPTION
preventing `unsupported protocol scheme ""`